### PR TITLE
Add Compatibility with the Venerable UK Finescale Tracks set (pb_trax.grf)

### DIFF
--- a/templates/nested/pantograph_switch.tmpl
+++ b/templates/nested/pantograph_switch.tmpl
@@ -10,7 +10,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.pantograph_unit}}_pantograph_state, current
 {
     ELRL: return switch_{{.pantograph_unit}}_pan_up_curve;
     SAAZ: return switch_{{.pantograph_unit}}_pan_up_curve;
-	railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve;
+    railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve;
     return switch_{{.pantograph_unit}}_pan_down_curve;
 }
 
@@ -19,7 +19,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.pantograph_unit}}_pantograph_state_front, c
 {
     ELRL: return switch_{{.pantograph_unit}}_pan_up_curve_front;
     SAAZ: return switch_{{.pantograph_unit}}_pan_up_curve_front;
-	railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve_front;
+    railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve_front;
     return switch_{{.pantograph_unit}}_pan_down_curve_front;
 }
 
@@ -27,7 +27,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.pantograph_unit}}_pantograph_state_rear, cu
 {
     ELRL: return switch_{{.pantograph_unit}}_pan_up_curve_rear;
     SAAZ: return switch_{{.pantograph_unit}}_pan_up_curve_rear;
-	railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve_rear;
+    railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve_rear;
     return switch_{{.pantograph_unit}}_pan_down_curve_rear;
 }
 {{end}}

--- a/templates/nested/pantograph_switch.tmpl
+++ b/templates/nested/pantograph_switch.tmpl
@@ -10,6 +10,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.pantograph_unit}}_pantograph_state, current
 {
     ELRL: return switch_{{.pantograph_unit}}_pan_up_curve;
     SAAZ: return switch_{{.pantograph_unit}}_pan_up_curve;
+	railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve;
     return switch_{{.pantograph_unit}}_pan_down_curve;
 }
 
@@ -18,6 +19,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.pantograph_unit}}_pantograph_state_front, c
 {
     ELRL: return switch_{{.pantograph_unit}}_pan_up_curve_front;
     SAAZ: return switch_{{.pantograph_unit}}_pan_up_curve_front;
+	railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve_front;
     return switch_{{.pantograph_unit}}_pan_down_curve_front;
 }
 
@@ -25,6 +27,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.pantograph_unit}}_pantograph_state_rear, cu
 {
     ELRL: return switch_{{.pantograph_unit}}_pan_up_curve_rear;
     SAAZ: return switch_{{.pantograph_unit}}_pan_up_curve_rear;
+	railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve_rear;
     return switch_{{.pantograph_unit}}_pan_down_curve_rear;
 }
 {{end}}

--- a/templates/nested/pantograph_switch.tmpl
+++ b/templates/nested/pantograph_switch.tmpl
@@ -10,7 +10,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.pantograph_unit}}_pantograph_state, current
 {
     ELRL: return switch_{{.pantograph_unit}}_pan_up_curve;
     SAAZ: return switch_{{.pantograph_unit}}_pan_up_curve;
-    railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve;
+    railtype("3RDC"): return switch_{{.pantograph_unit}}_pan_up_curve;
     return switch_{{.pantograph_unit}}_pan_down_curve;
 }
 
@@ -19,7 +19,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.pantograph_unit}}_pantograph_state_front, c
 {
     ELRL: return switch_{{.pantograph_unit}}_pan_up_curve_front;
     SAAZ: return switch_{{.pantograph_unit}}_pan_up_curve_front;
-    railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve_front;
+    railtype("3RDC"): return switch_{{.pantograph_unit}}_pan_up_curve_front;
     return switch_{{.pantograph_unit}}_pan_down_curve_front;
 }
 
@@ -27,7 +27,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.pantograph_unit}}_pantograph_state_rear, cu
 {
     ELRL: return switch_{{.pantograph_unit}}_pan_up_curve_rear;
     SAAZ: return switch_{{.pantograph_unit}}_pan_up_curve_rear;
-    railtype("3ORC"): return switch_{{.pantograph_unit}}_pan_up_curve_rear;
+    railtype("3RDC"): return switch_{{.pantograph_unit}}_pan_up_curve_rear;
     return switch_{{.pantograph_unit}}_pan_down_curve_rear;
 }
 {{end}}

--- a/templates/nested/visual_effect_power.tmpl
+++ b/templates/nested/visual_effect_power.tmpl
@@ -4,11 +4,14 @@
 {{ if eq .type "dual_power" -}}{{if .secondary_power}}
 switch (FEAT_TRAINS, SELF, switch_{{.id}}_power, current_railtype) {
     SAAZ: return {{.power}};
+	railtype("3ORC"): return {{.power}};
     {{ if eq .railtype "ELRL" }}
     ELRL: return {{.power}};
     {{ else }}
     SAA3: return {{.power}};
     TDRL: return {{.power}};
+    railtype("3RDR"): return {{.power}};
+    railtype("3RDC"): return {{.power}};
     {{ end }}
     return {{.secondary_power}};
 }{{end}}
@@ -27,6 +30,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.id}}_visual_effect_railtype, current_railty
 switch (FEAT_TRAINS, SELF, switch_{{.id}}_power, current_railtype) {
     ELRL: return {{.power}};
     SAAZ: return {{.power}};
+	railtype("3ORC"): return {{.power}};
     return {{.secondary_power}};
 }
 {{ end }}{{end}}

--- a/templates/nested/visual_effect_power.tmpl
+++ b/templates/nested/visual_effect_power.tmpl
@@ -4,7 +4,7 @@
 {{ if eq .type "dual_power" -}}{{if .secondary_power}}
 switch (FEAT_TRAINS, SELF, switch_{{.id}}_power, current_railtype) {
     SAAZ: return {{.power}};
-    railtype("3ORC"): return {{.power}};
+    railtype("3RDC"): return {{.power}};
     {{ if eq .railtype "ELRL" }}
     ELRL: return {{.power}};
     {{ else }}
@@ -30,7 +30,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.id}}_visual_effect_railtype, current_railty
 switch (FEAT_TRAINS, SELF, switch_{{.id}}_power, current_railtype) {
     ELRL: return {{.power}};
     SAAZ: return {{.power}};
-    railtype("3ORC"): return {{.power}};
+    railtype("3RDC"): return {{.power}};
     return {{.secondary_power}};
 }
 {{ end }}{{end}}

--- a/templates/nested/visual_effect_power.tmpl
+++ b/templates/nested/visual_effect_power.tmpl
@@ -4,7 +4,7 @@
 {{ if eq .type "dual_power" -}}{{if .secondary_power}}
 switch (FEAT_TRAINS, SELF, switch_{{.id}}_power, current_railtype) {
     SAAZ: return {{.power}};
-	railtype("3ORC"): return {{.power}};
+    railtype("3ORC"): return {{.power}};
     {{ if eq .railtype "ELRL" }}
     ELRL: return {{.power}};
     {{ else }}
@@ -30,7 +30,7 @@ switch (FEAT_TRAINS, SELF, switch_{{.id}}_visual_effect_railtype, current_railty
 switch (FEAT_TRAINS, SELF, switch_{{.id}}_power, current_railtype) {
     ELRL: return {{.power}};
     SAAZ: return {{.power}};
-	railtype("3ORC"): return {{.power}};
+    railtype("3ORC"): return {{.power}};
     return {{.secondary_power}};
 }
 {{ end }}{{end}}

--- a/templates/static/header.nml
+++ b/templates/static/header.nml
@@ -6,13 +6,13 @@ traininfo_y_offset=3;
 
  railtypetable {
     //3RDR is generic 3rd rail
-    //3RDC is some other kind of 3rd rail
-    //3ORC is dual power rails, at least in UK Finescale Tracks.
+    //3RDC is 3rd rail with catenary
+    //3ORC is a definition for vehicles - 3rd rail 'or' Catenary
     RAIL, ELRL, SAAZ, SAA3, TDRL, "3RDR", "3ORC", "3RDC",
     PLATEWAY: [PTWY,RAIL], 
     THIRD_RAIL: [TDRL,SAA3,"3RDR",ELRL],
     DUAL_POWER: [SAAZ,DUAL,SAA3,"3ORC",ELRL],
-    FOURTH_RAIL: [SAA4,MTRO,"3RDR","3RDC",ELRL],
+    FOURTH_RAIL: [SAA4,MTRO,"3RDR",ELRL],
     NARROW_GAUGE: [NGRL,NAAN],
 }
 

--- a/templates/static/header.nml
+++ b/templates/static/header.nml
@@ -5,9 +5,9 @@ traininfo_y_offset=3;
  disable_item(FEAT_TRAINS, 0, 115);
 
  railtypetable {
-	//3RDR is generic 3rd rail
-	//3RDC is some other kind of 3rd rail
-	//3ORC is dual power rails, at least in UK Finescale Tracks.
+    //3RDR is generic 3rd rail
+    //3RDC is some other kind of 3rd rail
+    //3ORC is dual power rails, at least in UK Finescale Tracks.
     RAIL, ELRL, SAAZ, SAA3, TDRL, "3RDR", "3ORC", "3RDC",
     PLATEWAY: [PTWY,RAIL], 
     THIRD_RAIL: [TDRL,SAA3,"3RDR",ELRL],

--- a/templates/static/header.nml
+++ b/templates/static/header.nml
@@ -5,13 +5,12 @@ traininfo_y_offset=3;
  disable_item(FEAT_TRAINS, 0, 115);
 
  railtypetable {
-    //3RDR is generic 3rd rail
-    //3RDC is 3rd rail with catenary
-    //3ORC is a definition for vehicles - 3rd rail 'or' Catenary
-    RAIL, ELRL, SAAZ, SAA3, TDRL, "3RDR", "3ORC", "3RDC",
+    //3RDR is generic 3rd rail, from old-school pb_trax.grf and friends
+    //3RDC is 3rd rail with catenary, from same
+    RAIL, ELRL, SAAZ, SAA3, TDRL, "3RDR", "3RDC",
     PLATEWAY: [PTWY,RAIL], 
     THIRD_RAIL: [TDRL,SAA3,"3RDR",ELRL],
-    DUAL_POWER: [SAAZ,DUAL,SAA3,"3ORC",ELRL],
+    DUAL_POWER: [SAAZ,DUAL,SAA3,ELRL],
     FOURTH_RAIL: [SAA4,MTRO,"3RDR",ELRL],
     NARROW_GAUGE: [NGRL,NAAN],
 }

--- a/templates/static/header.nml
+++ b/templates/static/header.nml
@@ -5,11 +5,14 @@ traininfo_y_offset=3;
  disable_item(FEAT_TRAINS, 0, 115);
 
  railtypetable {
-    RAIL, ELRL, SAAZ, SAA3, TDRL,
+	//3RDR is generic 3rd rail
+	//3RDC is some other kind of 3rd rail
+	//3ORC is dual power rails, at least in UK Finescale Tracks.
+    RAIL, ELRL, SAAZ, SAA3, TDRL, "3RDR", "3ORC", "3RDC",
     PLATEWAY: [PTWY,RAIL], 
-    THIRD_RAIL: [TDRL,SAA3,ELRL],
-    DUAL_POWER: [SAAZ,DUAL,SAA3,ELRL],
-    FOURTH_RAIL: [SAA4,MTRO,ELRL],
+    THIRD_RAIL: [TDRL,SAA3,"3RDR",ELRL],
+    DUAL_POWER: [SAAZ,DUAL,SAA3,"3ORC",ELRL],
+    FOURTH_RAIL: [SAA4,MTRO,"3RDR","3RDC",ELRL],
     NARROW_GAUGE: [NGRL,NAAN],
 }
 


### PR DESCRIPTION
By adding "3RDR"/"3RDC" support where needed.

I've tested it with the aforementioned set and tested it in a limited fashion with Timberwolf's Tracks 1.1.3, seems to work as I'd expect. Stops the 3rd rail stock running onto the OHLE from Finescale Tracks, lets the cute pantograph/power mode features work with that set too, as appropriate.

I checked the Javelin/325/73/Eurostar specifically on both sets on all the types of track.

This probably works with a lot of other (old) track sets, I'm happy to check it doesn't break on any that people have in mind.

Sorry about the messy series of commits. I don't use git in my day job. You'll certainly want to squash-merge them. Using git workflow is hard.